### PR TITLE
CSS changes to not allow user selection of hours, minutes or calendar days

### DIFF
--- a/app/styles/time-picker/interfaces/date-picker.scss
+++ b/app/styles/time-picker/interfaces/date-picker.scss
@@ -98,6 +98,7 @@ $day-size: ($ept-width * .1213);
 					font-weight: lighter;
 					line-height: $day-size + 3;
 					text-align: center;
+					user-select: none;
 
 					& > tr {
 						color: $ept-color-6-2;

--- a/app/styles/time-picker/interfaces/time-picker.scss
+++ b/app/styles/time-picker/interfaces/time-picker.scss
@@ -127,6 +127,7 @@ $clock-hand-stroke: ($ept-width * .0087);
 					font-weight: lighter;
 					line-height: 1;
 					fill: $ept-color-6-1;
+					user-select: none;
 				}
 
 				.cls-text-small {

--- a/app/styles/time-picker/interfaces/time-picker.scss
+++ b/app/styles/time-picker/interfaces/time-picker.scss
@@ -134,6 +134,7 @@ $clock-hand-stroke: ($ept-width * .0087);
 					font-weight: lighter;
 					line-height: 1;
 					fill: $ept-color-6-1;
+					user-select: none;
 				}
 
 				.cls-transparent {


### PR DESCRIPTION
Changed the CSS for the cls-text-small class so that the user can not select the text.
As I was using the add-on I would try and click on a time text in the clock and instead of clicking the text my web browser on occasion would select the text instead.

This small change prevents users from selecting the clock text numbers.